### PR TITLE
+text.getEffectiveFontSize

### DIFF
--- a/js/modules/gui/text.js
+++ b/js/modules/gui/text.js
@@ -852,7 +852,20 @@ bento.define('bento/gui/text', [
                 updateCanvas();
 
                 return fontSize / sharpness;
+            },
+            /**
+             * Retrieve the font size that was used to render the text
+             * @function
+             * @instance
+             * @name getEffectiveFontSize
+             * @returns Number
+             * @snippet #Text.getEffectiveFontSize|Number
+                getEffectiveFontSize();
+             */
+            getEffectiveFontSize: function () {
+                return fontSize / sharpness;
             }
+
         });
 
         applySettings(settings);


### PR DESCRIPTION
Adding a function to the Text module interface to get the font size that was actually used when rendering the text.

Currently, setText returns this value. I suppose it is used somewhere in a game currently, but I felt that 
a) it is quite an arbitrary return value for setText()
b) most importanly, it means that the only way to get this value is by re-rendering the entire canvas