### PR TITLE
*reworked transform.draw to only use save & restore when neccesary

### DIFF
--- a/js/transform.js
+++ b/js/transform.js
@@ -38,14 +38,14 @@ bento.define('bento/transform', [
     Transform.prototype.draw = function (data) {
         var entity = this.entity;
         var matrix = this.matrix;
-        var alpha = entity.alpha;
-        var rotation = entity.rotation;
+        var alpha = entity.alpha || 0;
+        var rotation = entity.rotation || 0;
         var renderer = data.renderer;
         var viewport = data.viewport;
         var tx = 0;
         var ty = 0;
-        var sx = entity.scale.x;
-        var sy = entity.scale.y;
+        var sx = entity.scale.x || 0;
+        var sy = entity.scale.y || 0;
 
         // translate
         if (Transform.subPixel) {
@@ -61,14 +61,18 @@ bento.define('bento/transform', [
             ty += -viewport.y;
         }
 
+        //safeguard against NaN position
+        tx = tx || 0;
+        ty = ty || 0;
+
         //this is an 'irreversable' operation, so we'll have to use save and restore
-        if (!sx || !sy) {
+        if (!sx || !sy){
             renderer.save();
         }
 
         // transform
         renderer.translate(tx, ty);
-        if (entity.rotation % twoPi) {
+        if (rotation % twoPi) {
             // rotated?
             renderer.rotate(rotation);
         }
@@ -90,7 +94,7 @@ bento.define('bento/transform', [
         var renderer = data.renderer;
 
         //this was an 'irreversable' operation, so we'll have to use save and restore
-        if (!this.sx || !this.sy) {
+        if (!this.sx || !this.sy){
             renderer.restore();
             return;
         }

--- a/js/transform.js
+++ b/js/transform.js
@@ -22,10 +22,10 @@ bento.define('bento/transform', [
         this.entity = entity;
 
         // cache values
-        this.oldAlpha = 1;        
+        this.oldAlpha = 1;
         this.tx = 0;
-        this.ty = 0; 
-        this.sx = 1; 
+        this.ty = 0;
+        this.sx = 1;
         this.sy = 1;
         this.r = 0;
 
@@ -47,26 +47,23 @@ bento.define('bento/transform', [
         var sx = entity.scale.x;
         var sy = entity.scale.y;
 
-        // check validity of transforms, 0 scale can not be reversed
-        // Note: will also skip on 0 alpha, not sure if developer still expects draw functions to run if alpha 0
-        if (!sx || !sy || !alpha) {
-            return false;
-        }
-
-        renderer.save();
-
         // translate
         if (Transform.subPixel) {
             tx += entity.position.x + this.x;
             ty += entity.position.y + this.y;
         } else {
             tx += Math.round(entity.position.x + this.x);
-            ty += entity.position.y + this.y;
+            ty += Math.round(entity.position.y + this.y);
         }
         // scroll (only applies to parent objects)
         if (!entity.parent && !entity.float) {
             tx += -viewport.x;
             ty += -viewport.y;
+        }
+
+        //this is an 'irreversable' operation, so we'll have to use save and restore
+        if (!sx || !sy) {
+            renderer.save();
         }
 
         // transform
@@ -92,6 +89,12 @@ bento.define('bento/transform', [
     Transform.prototype.postDraw = function (data) {
         var renderer = data.renderer;
 
+        //this was an 'irreversable' operation, so we'll have to use save and restore
+        if (!this.sx || !this.sy) {
+            renderer.restore();
+            return;
+        }
+
         // restore transforms
         renderer.setOpacity(this.oldAlpha);
         renderer.scale(1 / this.sx, 1 / this.sy);
@@ -100,8 +103,6 @@ bento.define('bento/transform', [
             renderer.rotate(-this.r);
         }
         renderer.translate(-this.tx, -this.ty);
-
-        renderer.restore();
     };
 
     Transform.prototype.getWorldPosition = function () {


### PR DESCRIPTION
I looked at this again based on a merge of an older version of this into Trigger Heroes (that didn't quite work).
    
There were 2 issues, both caused by the early exit:
a) on early exit, no transformations were applied, and the new values were not saved. However, in postDraw the reverse transformations were still executed. This then caused the next entity in line to be drawn with wildly inaccurate locations/rotations/etc.

b) once that was fixed, the early exit still caused an issue. If a parent A has a child B, and parent A had either a scale or alpha of 0, none of it's transformations would be applied. child B would still be drawn however, and while it normally shouldn't be visible, now it was (because A caused an early exit) and to make matters worse, it would be rendered on the wrong location.
    
My solution is to just use save+restore when the operation is irreversible (which is only if scale is 0 as far as I can tell), and do the reverse operations in all other scenarios. Since the reverse operations are faster, you'll gain speed in all cases except where a scale is 0 (and there won't be any speed lost there compared to the current system).
  
**Note**: If this ends up not being merged, at least the reverse operations in postDraw should be removed. They're just useless overhead now, as restore is called anyway. 