### PR TITLE
Eventsystem loop nest fix

### DIFF
--- a/build/bento.js
+++ b/build/bento.js
@@ -4704,7 +4704,7 @@ EventSystem.fire('${1}', ${2:data});
 bento.define('bento/eventsystem', [
     'bento/utils'
 ], function (Utils) {
-    var isLoopingEvents = false;
+    var isLoopingEvents = 0;
     var events = {};
     /*events = {
             [String eventName]: [Array listeners = {callback: Function, context: this}]
@@ -4713,7 +4713,7 @@ bento.define('bento/eventsystem', [
     var cleanEventListeners = function () {
         var i, j, l, listeners, eventName, callback, context;
 
-        if (isLoopingEvents) {
+        if (isLoopingEvents > 0) {
             return;
         }
         for (j = 0, l = removedEvents.length; j < l; ++j) {
@@ -4765,7 +4765,7 @@ bento.define('bento/eventsystem', [
             context: context
         });
 
-        if (!isLoopingEvents) {
+        if (isLoopingEvents === 0) {
             // can clean immediately
             cleanEventListeners();
         }
@@ -4780,7 +4780,7 @@ bento.define('bento/eventsystem', [
             reset: true
         });
 
-        if (!isLoopingEvents) {
+        if (isLoopingEvents === 0) {
             // can clean immediately
             cleanEventListeners();
         }
@@ -4836,8 +4836,8 @@ bento.define('bento/eventsystem', [
                 return;
             }
             listeners = events[eventName];
+            isLoopingEvents++;
             for (i = 0, l = listeners.length; i < l; ++i) {
-                isLoopingEvents = true;
                 listener = listeners[i];
                 if (listener) {
                     if (listener.context) {
@@ -4858,7 +4858,7 @@ bento.define('bento/eventsystem', [
                 }
 
             }
-            isLoopingEvents = false;
+            isLoopingEvents--;
         },
         addEventListener: addEventListener,
         removeEventListener: removeEventListener,
@@ -15214,7 +15214,7 @@ bento.define('bento/sortedeventsystem', [
         this.rootZ = rootZ;
     };
 
-    var isLoopingEvents = false;
+    var isLoopingEvents = 0;
     var objects = null;
     var events = {};
     /*events = {
@@ -15224,7 +15224,7 @@ bento.define('bento/sortedeventsystem', [
     var cleanEventListeners = function () {
         var i, j, l, listeners, eventName, callback, context;
 
-        if (isLoopingEvents) {
+        if (isLoopingEvents > 0) {
             return;
         }
         for (j = 0, l = removedEvents.length; j < l; ++j) {
@@ -15283,7 +15283,7 @@ bento.define('bento/sortedeventsystem', [
             context: context
         });
 
-        if (!isLoopingEvents) {
+        if (isLoopingEvents === 0) {
             // can clean immediately
             cleanEventListeners();
         }
@@ -15298,7 +15298,7 @@ bento.define('bento/sortedeventsystem', [
             reset: true
         });
 
-        if (!isLoopingEvents) {
+        if (isLoopingEvents === 0) {
             // can clean immediately
             cleanEventListeners();
         }
@@ -15434,8 +15434,8 @@ bento.define('bento/sortedeventsystem', [
             inspectSortingData(listeners);
             sortListeners(listeners);
 
+            isLoopingEvents++;
             for (i = 0, l = listeners.length; i < l; ++i) {
-                isLoopingEvents = true;
                 listener = listeners[i];
                 if (listener) {
                     if (listener.context) {
@@ -15455,7 +15455,7 @@ bento.define('bento/sortedeventsystem', [
                     break;
                 }
             }
-            isLoopingEvents = false;
+            isLoopingEvents--;
         },
         addEventListener: addEventListener,
         removeEventListener: removeEventListener,
@@ -19704,7 +19704,7 @@ bento.define('bento/gui/text', [
                     applySettings(settings);
                 }
             }
-            
+
             strings = [];
             canvasWidth = 1;
             canvasHeight = 1;

--- a/js/eventsystem.js
+++ b/js/eventsystem.js
@@ -16,7 +16,7 @@ EventSystem.fire('${1}', ${2:data});
 bento.define('bento/eventsystem', [
     'bento/utils'
 ], function (Utils) {
-    var isLoopingEvents = false;
+    var isLoopingEvents = 0;
     var events = {};
     /*events = {
             [String eventName]: [Array listeners = {callback: Function, context: this}]
@@ -25,7 +25,7 @@ bento.define('bento/eventsystem', [
     var cleanEventListeners = function () {
         var i, j, l, listeners, eventName, callback, context;
 
-        if (isLoopingEvents) {
+        if (isLoopingEvents > 0) {
             return;
         }
         for (j = 0, l = removedEvents.length; j < l; ++j) {
@@ -77,7 +77,7 @@ bento.define('bento/eventsystem', [
             context: context
         });
 
-        if (!isLoopingEvents) {
+        if (isLoopingEvents === 0) {
             // can clean immediately
             cleanEventListeners();
         }
@@ -92,7 +92,7 @@ bento.define('bento/eventsystem', [
             reset: true
         });
 
-        if (!isLoopingEvents) {
+        if (isLoopingEvents === 0) {
             // can clean immediately
             cleanEventListeners();
         }
@@ -148,8 +148,8 @@ bento.define('bento/eventsystem', [
                 return;
             }
             listeners = events[eventName];
+            isLoopingEvents++;
             for (i = 0, l = listeners.length; i < l; ++i) {
-                isLoopingEvents = true;
                 listener = listeners[i];
                 if (listener) {
                     if (listener.context) {
@@ -170,7 +170,7 @@ bento.define('bento/eventsystem', [
                 }
 
             }
-            isLoopingEvents = false;
+            isLoopingEvents--;
         },
         addEventListener: addEventListener,
         removeEventListener: removeEventListener,

--- a/js/modules/sortedeventsystem.js
+++ b/js/modules/sortedeventsystem.js
@@ -71,7 +71,7 @@ bento.define('bento/sortedeventsystem', [
         this.rootZ = rootZ;
     };
 
-    var isLoopingEvents = false;
+    var isLoopingEvents = 0;
     var objects = null;
     var events = {};
     /*events = {
@@ -81,7 +81,7 @@ bento.define('bento/sortedeventsystem', [
     var cleanEventListeners = function () {
         var i, j, l, listeners, eventName, callback, context;
 
-        if (isLoopingEvents) {
+        if (isLoopingEvents > 0) {
             return;
         }
         for (j = 0, l = removedEvents.length; j < l; ++j) {
@@ -140,7 +140,7 @@ bento.define('bento/sortedeventsystem', [
             context: context
         });
 
-        if (!isLoopingEvents) {
+        if (isLoopingEvents === 0) {
             // can clean immediately
             cleanEventListeners();
         }
@@ -155,7 +155,7 @@ bento.define('bento/sortedeventsystem', [
             reset: true
         });
 
-        if (!isLoopingEvents) {
+        if (isLoopingEvents === 0) {
             // can clean immediately
             cleanEventListeners();
         }
@@ -291,8 +291,8 @@ bento.define('bento/sortedeventsystem', [
             inspectSortingData(listeners);
             sortListeners(listeners);
 
+            isLoopingEvents++;
             for (i = 0, l = listeners.length; i < l; ++i) {
-                isLoopingEvents = true;
                 listener = listeners[i];
                 if (listener) {
                     if (listener.context) {
@@ -312,7 +312,7 @@ bento.define('bento/sortedeventsystem', [
                     break;
                 }
             }
-            isLoopingEvents = false;
+            isLoopingEvents--;
         },
         addEventListener: addEventListener,
         removeEventListener: removeEventListener,


### PR DESCRIPTION
if a callback for event A itself fires an event B, the loop for event B will finish first and set isLoopingEvents to false. This can lead to `cleanEventListeners` being executed while the loop for A was still going on. if one of the callbacks for event A is removed in the meantime, this changes the length of the listener array for event A while it is still being looped through.

```javascript
var callback = function () {
    if (someConditionIsMet) {
        EventSystem.fire(B, {});
        //EventSystem::isLoopingEvents is false here, because the 
        //loop for event B just completed. This causes the next 
        //call to off to immediately clean the events, even though
        //the loop for event A is still going on
        EventSystem.off(A, callback);
    }
};

EventSystem.on(A, callback);
```

This commit changes isLoopingEvents from a boolean to an int, counting up whenever a loop starts and counting down whenever it's finished. This way events should never get cleaned in the event of recursion.