### PR TITLE
Rewritten AutoResize, fixed 'resize' event callback.

### DIFF
--- a/js/bento.js
+++ b/js/bento.js
@@ -295,12 +295,12 @@ bento.define('bento', [
          * @param {Boolean} settings.preventContextMenu - Stops the context menu from appearing in browsers when using right click
          * @param {Boolean} settings.autoDisposeTextures - Removes all internal textures on screen ends to reduce memory usage
          * @param {Object} settings.responsiveResize - Bento's strategy of resizing to mobile screen sizes. 
-         * In case of portrait: Bento locks the width and fills the height. If min/max height is reached, the width is adapted up to its min/max.
-         * @param {Boolean} settings.responsiveResize.landscape - Portrait (false) or Landscape (true)
-         * @param {Number} settings.responsiveResize.minWidth - Minimum width
-         * @param {Number} settings.responsiveResize.maxWidth - Maximum width
-         * @param {Number} settings.responsiveResize.minHeight - Minimum height
-         * @param {Number} settings.responsiveResize.maxHeight - Maximum height
+         * In case of portrait: Bento locks the  min height and fills the width by aspect ratio until the max width is reached. If min width is reached, the height is then adapted by aspect ratio up to it's defined maximum.
+         * @param {Number} settings.responsiveResize.minWidth - Minimum width in portrait.
+         * @param {Number} settings.responsiveResize.maxWidth - Maximum width in portrait.
+         * @param {Number} settings.responsiveResize.minHeight - Minimum height in portrait.
+         * @param {Number} settings.responsiveResize.maxHeight - Maximum height in portrait.
+         * @param {String} settings.responsiveResize.lockedRotation - 'portrait' or 'landscape' enforces an aspect ratio corrseponding to this, instead of handling this automatically, unnecessary to be used if enforcable by another means
          * @param {Object} settings.reload - Settings for module reloading, set the event names for Bento to listen
          * @param {String} settings.reload.simple - Event name for simple reload: reloads modules and resets current screen
          * @param {String} settings.reload.assets - Event name for asset reload: reloads modules and all assets and resets current screen

--- a/js/managers/input.js
+++ b/js/managers/input.js
@@ -188,7 +188,8 @@ bento.define('bento/managers/input', [
                 evt.id = -1;
             },
             updatePointer = function (evt) {
-                var i = 0, l;
+                var i = 0,
+                    l;
                 for (i = 0, l = pointers.length; i < l; ++i) {
                     if (pointers[i].id === evt.id) {
                         pointers[i].position = evt.position;
@@ -199,7 +200,8 @@ bento.define('bento/managers/input', [
                 }
             },
             removePointer = function (evt) {
-                var i = 0, l;
+                var i = 0,
+                    l;
                 for (i = 0, l = pointers.length; i < l; ++i) {
                     if (pointers[i].id === evt.id) {
                         pointers.splice(i, 1);
@@ -442,7 +444,8 @@ bento.define('bento/managers/input', [
              * continually checking for input is the only way for now.
              */
             initRemote = function () {
-                var i = 0, l,
+                var i = 0,
+                    l,
                     tvOSGamepads;
 
                 if (window.ejecta) {
@@ -479,7 +482,8 @@ bento.define('bento/managers/input', [
                 }
             },
             remoteButtonDown = function (id) {
-                var i = 0, l,
+                var i = 0,
+                    l,
                     names = Utils.remoteMapping[id];
                 // save value in array
                 remoteButtonsPressed[id] = true;
@@ -488,7 +492,8 @@ bento.define('bento/managers/input', [
                     remoteButtonStates[names[i]] = true;
             },
             remoteButtonUp = function (id) {
-                var i = 0, l,
+                var i = 0,
+                    l,
                     names = Utils.remoteMapping[id];
                 // save value in array
                 remoteButtonsPressed[id] = false;
@@ -594,8 +599,6 @@ bento.define('bento/managers/input', [
         // note: it's a bit tricky with order of event listeners, make sure resizing is done first
         // otherwise updateCanvas needs to be called manually afterwards
         if (canvas) {
-            window.addEventListener('resize', updateCanvas, false);
-            window.addEventListener('orientationchange', updateCanvas, false);
             updateCanvas();
         }
 

--- a/js/modules/autoresize.js
+++ b/js/modules/autoresize.js
@@ -34,11 +34,11 @@ bento.define('bento/autoresize', [
 
         // create new object with correctly scaled and clamped dimensions
         var newDimension = (isPortrait) ? {
-            width: Utils.clamp(minWidth, minHeight * ratio, maxWidth),
-            height: Utils.clamp(minHeight, minWidth / ratio, maxHeight)
+            width: Math.ceil(Utils.clamp(minWidth, minHeight * ratio, maxWidth)),
+            height: Math.ceil(Utils.clamp(minHeight, minWidth / ratio, maxHeight))
         } : {
-            width: Utils.clamp(minHeight, minWidth * ratio, maxHeight),
-            height: Utils.clamp(minWidth, minHeight / ratio, maxWidth)
+            width: Math.ceil(Utils.clamp(minHeight, minWidth * ratio, maxHeight)),
+            height: Math.ceil(Utils.clamp(minWidth, minHeight / ratio, maxWidth))
         };
         return newDimension;
     };


### PR DESCRIPTION
The AutoResize module was way too complex for the simplicity of what it actually did, and was written in a way that was unnecessarily confusing, effectively being two sets of code swapped by a ternary depending on whether it was intended to be landscape or not. 
Here the dimensions are defined by what they would be in portrait, regardless of intended orientation, using the height as the width and width as height when a in landscape mode. This rewrite doesn't alter the method we had before for handling aspect ratio, but is now in a much more simple form (just scaling and clamping). There is also a parameter to enforce a set orientation, but it is not required if enforceable by another means (e.g. config.xml).

Another change here is how the 'resize' event is handled. As the 'orientationchanged' is fired at the same time, 'orientationchanged' is now ignored. As well as this, there is now a 100ms timeout that resets itself when fired again on the callback for 'resize', preventing multiple events from firing in rapid succession, which lead to the weird rotation behaviour seen before (likely due to iOS resize animations). the last small addition is manually firing Bento.input.updateCanvas, after the OnResize callback, as to better coordinate resizing in general.
