### PR TITLE
Tween updatewhenpaused fix

### DIFF
--- a/js/modules/tween.js
+++ b/js/modules/tween.js
@@ -490,6 +490,8 @@ bento.define('bento/tween', [
         // one wants to see the tween move during that pause
         if (!Utils.isDefined(settings.updateWhenPaused)) {
             tweenBehavior.updateWhenPaused = Bento.objects.isPaused();
+        } else {
+            tweenBehavior.updateWhenPaused = settings.updateWhenPaused;
         }
 
         // tween automatically starts


### PR DESCRIPTION
this got lost when converting Tweens from entities to Behaviors (originally, the whole settings object was just passed to the Entity constructor, and hence the updateWhenPaused property was applied to the Entity)