### PR TITLE
Support for Tiled flip flags on object layers.  Added resize event.

### DIFF
--- a/js/bento.js
+++ b/js/bento.js
@@ -227,6 +227,7 @@ bento.define('bento', [
         }
         // update input and canvas
         Bento.input.updateCanvas();
+        EventSystem.fire('resize', viewport);
         // clear the task id
         resizeTaskId = null;
     };

--- a/js/modules/tiled.js
+++ b/js/modules/tiled.js
@@ -372,7 +372,6 @@ bento.define('bento/tiled', [
 
                 // get source position
                 var source = getSourceTile(tileSet, tileIndex);
-                var layerIndex = currentLayer;
 
                 // retrieve the corresponding image asset
                 // there is a very high chance the url contains "images/" since the json files
@@ -398,12 +397,12 @@ bento.define('bento/tiled', [
                 );
 
                 if (onTile) {
-                    onTile.call(tiled, tileX, tileY, tileSet, tileIndex, flipX, flipY, flipD, layerIndex);
+                    onTile.call(tiled, tileX, tileY, tileSet, tileIndex, flipX, flipY, flipD, currentLayer);
                 }
             },
-            onObject: function (object, tileSet, tileIndex) {
+            onObject: function (object, tileSet, tileIndex, flipX, flipY, flipDiagonal) {
                 if (onObject) {
-                    onObject.call(tiled, object, tileSet, tileIndex, currentLayer);
+                    onObject.call(tiled, object, tileSet, tileIndex, flipX, flipY, flipDiagonal, currentLayer);
                 }
                 if (settings.spawnEntities) {
                     // note: we can pass currentLayer, as onLayer is synchronously called before onObject

--- a/js/modules/tiledreader.js
+++ b/js/modules/tiledreader.js
@@ -166,14 +166,27 @@ bento.define('bento/tiledreader', [], function () {
                 onTile(x, y, tilesetData.tileSet, tileIndex, flipX, flipY, flipDiagonal);
             };
             var objectCallback = function (object) {
-                var tileIndex;
                 var tilesetData;
+                var tileIndex;
+                var flipX;
+                var flipY;
+                var flipDiagonal;
                 var gid = object.gid;
                 if (gid) {
+                    // read out the flags
+                    flipX = (gid & FLIPX);
+                    flipY = (gid & FLIPY);
+                    flipDiagonal = (gid & FLIPDIAGONAL);
+
+                    // clear flags
+                    gid &= ~(FLIPX | FLIPY | FLIPDIAGONAL);
+
                     // get the corresponding tileset and tile index
                     tilesetData = getTileset(gid);
                     tileIndex = gid - tilesetData.firstGid;
-                    onObject(object, tilesetData.tileSet, tileIndex);
+                    
+                    // callback
+                    onObject(object, tilesetData.tileSet, tileIndex, flipX, flipY, flipDiagonal);
                 } else {
                     // gid may not be present, in that case it's a rectangle or other shape
                     onObject(object);


### PR DESCRIPTION
TiledReader onObject callback now has the following signature:

```js
onObject (objectJSON, tilesetJSON, tileIndex, flipX, flipY, flipDiagonal) {
    ...
}
```

Similarly, the Tiled module onObject callback now has the following signature:

```js
onObject (objectJSON, tilesetJSON, tileIndex, flipX, flipY, flipDiagonal, layerIndex) {
    ...
}
```

Note: `layerIndex` has moved position, which could cause incompatibility with existing projects (and in some cases it may be called `currentLayer`)

--

Additionally, Bento now fires a 'resize' event of its own, since resizing the window is delayed by 100ms from the window's resize event.