### PR TITLE
Added Rik's linebreak fix to the text module

### DIFF
--- a/js/modules/gui/text.js
+++ b/js/modules/gui/text.js
@@ -108,6 +108,7 @@ bento.define('bento/gui/text', [
         }*/
         var text = '';
         var linebreaks = true;
+        var linebreaksOnlyOnSpace = false;
         var maxWidth;
         var maxHeight;
         var fontWeight = 'normal';
@@ -302,6 +303,9 @@ bento.define('bento/gui/text', [
              */
             if (Utils.isDefined(textSettings.linebreaks)) {
                 linebreaks = textSettings.linebreaks;
+            }
+            if (Utils.isDefined(textSettings.linebreaksOnlyOnSpace)) {
+                linebreaksOnlyOnSpace = textSettings.linebreaksOnlyOnSpace;
             }
             if (Utils.isDefined(textSettings.maxWidth)) {
                 maxWidth = textSettings.maxWidth * sharpness;
@@ -658,24 +662,30 @@ bento.define('bento/gui/text', [
                             break;
                         }
                     }
-                    // find first space to split (if there are no spaces, we just split at our current position)
-                    spacePos = subString.lastIndexOf(' ');
-                    if (spacePos > 0 && spacePos != subString.length) {
-                        // set splitting position
-                        j += subString.length - spacePos;
-                    }
-                    // split the string into 2
-                    remainingString = singleString.slice(l - j, l);
-                    singleString = singleString.slice(0, l - j);
+                    if (!(linebreaksOnlyOnSpace && singleString.indexOf(' ') == -1 && singleString.indexOf('\u200b') == -1) ) {
+                        // find first space to split (if there are no spaces, we just split at our current position)
+                        spacePos = Math.max(subString.lastIndexOf(' '), subString.lastIndexOf('\u200b'));
+                        if (spacePos > 0 && spacePos != subString.length) {
+                            // set splitting position
+                            j += subString.length - spacePos;
+                        } else {
+                            if (linebreaksOnlyOnSpace) {
+                                j = 0;
+                            }
+                        }
+                        // split the string into 2
+                        remainingString = singleString.slice(l - j, l);
+                        singleString = singleString.slice(0, l - j);
 
-                    // remove first space in remainingString
-                    if (remainingString.charAt(0) === ' ') {
-                        remainingString = remainingString.slice(1);
-                    }
+                        // remove first space in remainingString
+                        if (remainingString.charAt(0) === ' ') {
+                            remainingString = remainingString.slice(1);
+                        }
 
-                    // the remaining string will be pushed into the array right after this one
-                    if (remainingString.length !== 0) {
-                        singleStrings.splice(i + 1, 0, remainingString);
+                        // the remaining string will be pushed into the array right after this one
+                        if (remainingString.length !== 0) {
+                            singleStrings.splice(i + 1, 0, remainingString);
+                        }
                     }
 
                     // set width correctly and proceed


### PR DESCRIPTION
This allows you to pass `linebreaksOnlyOnSpace: true` to a Text component, which can fix cases where a line break may occur in the middle of a single word.

Also includes Robin's addition: When using this setting, a zero-width space (`\u200b`) can be used to force a linebreak where one wouldn't normally occur, which can be useful when working with zh/ja locales.