### PR TITLE
Don't mutate shadowOffset when applying text settings

### DIFF
--- a/js/modules/gui/text.js
+++ b/js/modules/gui/text.js
@@ -284,7 +284,7 @@ bento.define('bento/gui/text', [
             if (Utils.isDefined(textSettings.shadow)) {
                 shadow = textSettings.shadow;
                 if (Utils.isDefined(textSettings.shadowOffset)) {
-                    shadowOffset = textSettings.shadowOffset.scalarMultiplyWith(sharpness);
+                    shadowOffset = textSettings.shadowOffset.scalarMultiply(sharpness);
                 } else {
                     if (shadow) {
                         // default is 1 pixel down


### PR DESCRIPTION
This would have very bad consequences when using the same settings object to initialize multiple Text objects.