### PR TITLE
Add `global` setting to EventListener component

### DIFF
--- a/js/bento.js
+++ b/js/bento.js
@@ -562,8 +562,8 @@ bento.define('bento', [
                     // restart the mainloop
                     Bento.objects.run();
                     /**
-                     * Fired when using Bento's quick reload feature
-                     * @event bentoReload 
+                     * Fired when using Bento's quick reload feature, <em>after</em> the new screen was shown.
+                     * @event bentoReload
                      */
                     EventSystem.fire('bentoReload', {});
                 }

--- a/js/managers/object.js
+++ b/js/managers/object.js
@@ -99,6 +99,15 @@ bento.define('bento/managers/object', [
 
             lastFrameTime = time;
 
+            if (!isRunning) {
+                /**
+                 * Fired at the end of the frame on which Bento.objects.stop() was called.
+                 * This can be useful to clean up on hot-reload, before the new screen is shown.
+                 * @event bentoStop
+                 */
+                EventSystem.fire('bentoStop');
+            }
+
             Loop.run(mainLoop);
         };
         var currentObject; // the current object being processed in the main loop


### PR DESCRIPTION
This keeps the EventListener alive across screens, but ensures that it will be correctly destroyed on quick-reload.

This is achieved with a new event called `bentoStop` which is fired at the end of the frame when `Bento.objects.stop()` was called (meaning a quick reload occurred).

Example EventListener usage:

```js
/**
 * Level scenery for kitchen themes.
 * @moduleName LevelDecor
 */
bento.define('entities/kitchen/leveldecor', [
    'bento',
    'onigiri/onigiri',
    'components/eventlistener'
], function (
    Bento,
    Onigiri,
    EventListener
) {
    'use strict';

    let counterTopMaterial = new THREE.MeshPhongMaterial({});
    let backWallMaterial = new THREE.MeshLambertMaterial({});
    let ceramicsMaterial = new THREE.MeshPhongMaterial({});

    let applyTheme = function (theme) {
        let {
            ceramicsColor = 0xdddddd,
            counterTopColor = 0x2da390,
            wallpaperColor = 0xffffff,
        } = theme;
        backWallMaterial.color.set(wallpaperColor);
        counterTopMaterial.color.set(counterTopColor);
        ceramicsMaterial.color.set(ceramicsColor);
    };

    // set default theme
    applyTheme({});

    // global event listener, removes self before bentoReload
    Bento.objects.attach(new EventListener({
        eventName: 'themeChanged',
        global: true,
        ignorePause: true,
        onEvent: applyTheme
    }));

    return function (settings) {

        let group = new THREE.Group();

        // ...
        // Load meshes, make them use the materials, add them to group
        // ...

        let entity = new Onigiri.Entity3D({
            name: 'leveldecor',
            object3D: group,
            position: new THREE.Vector3(0, 0, 0),
            euler: new THREE.Euler(0, 0, 0),
        });

        return entity;
    };
});
```